### PR TITLE
feat(node): handle custom components for unknown node types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -286,6 +286,12 @@ export function createVNode(node: Node, options: ToVNodeOptions = {}, context: C
           )
     }
     default: {
+      if(nodeComponent) {
+        return h(
+          nodeComponent,
+          nodeComponentProps,
+        )
+      }
       return h(Comment, JSON.stringify(node))
     }
   }


### PR DESCRIPTION
Hi! I'm using this library to render Markdown in my project. I encountered an issue where math-related node types (`math` and `inlineMath`) weren't being rendered properly even when specifying custom components.

To reproduce:

```typescript
const text = `
# test

$$
a^2 + b^2 = c^2
$$
`

const processor = unified()
  .use(remarkParse)
  .use(remarkMath)
const tree = processor.parse(text)
const vnode = toVNode(tree, {
  components: {
    inlineMath: (node: any) => h('span', { innerHTML: node.value }),
    math: (node: any) => h('span', { innerHTML: node.value }),
  }
})
// math related nodes are converted to comments
```

This change adds a fallback routine to properly handle node types that don't match any existing cases in the switch statement. Now when a component is provided for an unhandled node type, it will correctly render using that component rather than falling back to a JSON comment.

Thanks for considering this contribution!